### PR TITLE
Update schedule on frontend when meeting is created

### DIFF
--- a/app/js/controllers/meeting_controller.coffee
+++ b/app/js/controllers/meeting_controller.coffee
@@ -33,8 +33,9 @@ angular.module 'tandemApp'
       evening: true
   ]
 
-  Meeting.addMeeting().$promise.then (meeting) ->
-    $scope.meeting.id = meeting._id
+  Meeting.addMeeting().$promise.then (res) ->
+    $scope.meeting.id = res.meeting_id
+    $scope.meeting.schedule = res.schedule
 
   $scope.addAttendee = ->
     duplicate = $scope.meeting.attendees.some (elem) ->


### PR DESCRIPTION
This is to accept the calendar data of the meeting initiator when the schedule page is first loaded.